### PR TITLE
Fix resources and api exports

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,0 +1,1 @@
+export 'src/api/api.dart';

--- a/lib/resources.dart
+++ b/lib/resources.dart
@@ -1,0 +1,1 @@
+export 'src/resources/resources.dart';

--- a/lib/src/api/api.dart
+++ b/lib/src/api/api.dart
@@ -1,0 +1,4 @@
+export 'bucket.dart';
+export 'collection.dart';
+export 'secret.dart';
+export 'topic.dart';

--- a/lib/src/resources/resources.dart
+++ b/lib/src/resources/resources.dart
@@ -1,0 +1,1 @@
+export 'common.dart';


### PR DESCRIPTION
Add barrel exports to the `resources` and `api` folders and export those from the root `lib` level.

This should remove analysis errors when referencing private modules.