### PR TITLE
Rename package to `nitric_sdk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ dart create -t console my-profile-api
 Add the Nitric SDK by adding the repository URL to your `pubspec.yaml`.
 
 ```yaml
-nitric-sdk:
+nitric_sdk:
   git:
     url: https://github.com/nitrictech/dart-sdk.git
     ref: main
@@ -143,9 +143,9 @@ Applications built with Nitric can contain many APIs, let's start by adding one 
 ```dart
 import 'package:uuid/uuid.dart';
 
-import 'package:dart_sdk/src/api/collection.dart';
-import 'package:dart_sdk/src/nitric.dart';
-import 'package:dart_sdk/src/resources/common.dart';
+import 'package:nitric_sdk/src/api/collection.dart';
+import 'package:nitric_sdk/src/nitric.dart';
+import 'package:nitric_sdk/src/resources/common.dart';
 
 void main() {
   // Create an API named 'public'

--- a/example/nitric_example.dart
+++ b/example/nitric_example.dart
@@ -1,6 +1,6 @@
-import 'package:dart_sdk/src/api/collection.dart';
-import 'package:dart_sdk/src/nitric.dart';
-import 'package:dart_sdk/src/resources/common.dart';
+import 'package:nitric_sdk/src/api/collection.dart';
+import 'package:nitric_sdk/src/nitric.dart';
+import 'package:nitric_sdk/src/resources/common.dart';
 import 'package:uuid/uuid.dart';
 
 class Profile {

--- a/lib/src/api/bucket.dart
+++ b/lib/src/api/bucket.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:dart_sdk/src/context/common.dart';
-import 'package:dart_sdk/src/nitric/proto/storage/v1/storage.pbgrpc.dart' as $p;
-import 'package:dart_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
+import 'package:nitric_sdk/src/context/common.dart';
+import 'package:nitric_sdk/src/nitric/proto/storage/v1/storage.pbgrpc.dart'
+    as $p;
+import 'package:nitric_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 

--- a/lib/src/api/secret.dart
+++ b/lib/src/api/secret.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
-import 'package:dart_sdk/src/nitric/proto/secrets/v1/secrets.pbgrpc.dart' as $p;
+import 'package:nitric_sdk/src/nitric/proto/secrets/v1/secrets.pbgrpc.dart'
+    as $p;
 import 'package:grpc/grpc.dart';
 
 /// References an encrypted secret stored in a secret manager.

--- a/lib/src/api/topic.dart
+++ b/lib/src/api/topic.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
-import 'package:dart_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
-import 'package:dart_sdk/src/nitric/google/protobuf/struct.pb.dart';
-import 'package:dart_sdk/src/nitric/proto/topics/v1/topics.pbgrpc.dart' as $p;
+import 'package:nitric_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
+import 'package:nitric_sdk/src/nitric/google/protobuf/struct.pb.dart';
+import 'package:nitric_sdk/src/nitric/proto/topics/v1/topics.pbgrpc.dart' as $p;
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 

--- a/lib/src/context/common.dart
+++ b/lib/src/context/common.dart
@@ -2,13 +2,13 @@ library context;
 
 import 'dart:convert';
 
-import 'package:dart_sdk/src/api/bucket.dart';
-import 'package:dart_sdk/src/nitric/proto/apis/v1/apis.pb.dart' as $ap;
-import 'package:dart_sdk/src/nitric/proto/schedules/v1/schedules.pb.dart'
+import 'package:nitric_sdk/src/api/bucket.dart';
+import 'package:nitric_sdk/src/nitric/proto/apis/v1/apis.pb.dart' as $ap;
+import 'package:nitric_sdk/src/nitric/proto/schedules/v1/schedules.pb.dart'
     as $sp;
-import 'package:dart_sdk/src/nitric/proto/topics/v1/topics.pb.dart' as $ep;
-import 'package:dart_sdk/src/nitric/proto/storage/v1/storage.pb.dart' as $bp;
-import 'package:dart_sdk/src/nitric/proto/websockets/v1/websockets.pb.dart'
+import 'package:nitric_sdk/src/nitric/proto/topics/v1/topics.pb.dart' as $ep;
+import 'package:nitric_sdk/src/nitric/proto/storage/v1/storage.pb.dart' as $bp;
+import 'package:nitric_sdk/src/nitric/proto/websockets/v1/websockets.pb.dart'
     as $wp;
 import 'package:meta/meta.dart';
 

--- a/lib/src/resources/common.dart
+++ b/lib/src/resources/common.dart
@@ -3,23 +3,24 @@ library resources;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:dart_sdk/src/api/collection.dart';
-import 'package:dart_sdk/src/nitric/proto/websockets/v1/websockets.pb.dart';
+import 'package:nitric_sdk/src/api/collection.dart';
+import 'package:nitric_sdk/src/nitric/proto/websockets/v1/websockets.pb.dart';
 import 'package:grpc/grpc.dart';
 import 'package:fixnum/fixnum.dart';
-import 'package:dart_sdk/src/context/common.dart';
-import 'package:dart_sdk/src/api/bucket.dart';
-import 'package:dart_sdk/src/api/topic.dart' as $t;
-import 'package:dart_sdk/src/api/secret.dart' as $s;
+import 'package:nitric_sdk/src/context/common.dart';
+import 'package:nitric_sdk/src/api/bucket.dart';
+import 'package:nitric_sdk/src/api/topic.dart' as $t;
+import 'package:nitric_sdk/src/api/secret.dart' as $s;
 
-import 'package:dart_sdk/src/nitric/proto/resources/v1/resources.pbgrpc.dart'
+import 'package:nitric_sdk/src/nitric/proto/resources/v1/resources.pbgrpc.dart'
     as $p;
-import 'package:dart_sdk/src/nitric/proto/apis/v1/apis.pbgrpc.dart' as $ap;
-import 'package:dart_sdk/src/nitric/proto/schedules/v1/schedules.pbgrpc.dart'
+import 'package:nitric_sdk/src/nitric/proto/apis/v1/apis.pbgrpc.dart' as $ap;
+import 'package:nitric_sdk/src/nitric/proto/schedules/v1/schedules.pbgrpc.dart'
     as $sp;
-import 'package:dart_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
-import 'package:dart_sdk/src/nitric/proto/topics/v1/topics.pbgrpc.dart' as $tp;
-import 'package:dart_sdk/src/nitric/proto/websockets/v1/websockets.pbgrpc.dart'
+import 'package:nitric_sdk/src/nitric/google/protobuf/duration.pb.dart' as $d;
+import 'package:nitric_sdk/src/nitric/proto/topics/v1/topics.pbgrpc.dart'
+    as $tp;
+import 'package:nitric_sdk/src/nitric/proto/websockets/v1/websockets.pbgrpc.dart'
     as $wp;
 import 'package:meta/meta.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: dart_sdk
+name: nitric_sdk
 description: A Dart SDK for creating Nitric applications
 version: 1.0.0
 repository: https://github.com/nitrictech/dart_sdk


### PR DESCRIPTION
This commit renames the package name from `dart_sdk` to `nitric_sdk` to match the naming convention of the other language SDKs.

Closes #2 