### PR TITLE
Update example with a full dart project

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,13 @@
+A server app built using [Nitric](nitric.io) with an entrypoint in `bin/`, library code
+in `lib/`, and example unit test in `test/`.
+
+# Running the sample
+
+## Running with the Dart SDK
+
+You can run the example with the [Dart SDK](https://dart.dev/get-dart)
+like this:
+
+```
+$ dart run bin/example.dart
+```

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,16 @@
+name: example
+description: A sample command-line application.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.2.5
+
+dependencies:
+  nitric_sdk:
+    path: ../
+  uuid: ^4.3.3
+
+dev_dependencies:
+  lints: ^2.1.0
+  test: ^1.24.0

--- a/lib/resource.dart
+++ b/lib/resource.dart
@@ -1,0 +1,1 @@
+export 'src/resources/resources.dart';


### PR DESCRIPTION
Update the example with a full dart project that includes references to nitric.

Notes:

I noticed that the API does not currently work with `nitric start` which produces the following error:

```bash
ERROR   unable to create build context for service file bin/example.dart: nitric does not support files with extension .dart by default
```

Attempting to use `dart run` also produces a weird error:

```bash
Unhandled exception:
gRPC Error (code: 12, codeName: UNIMPLEMENTED, message: unknown service nitric.proto.resources.v1.Resources, details: [], rawResponse: null, trailers: {})
```
